### PR TITLE
perf: Prevent possible memory leaks on the server

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
   "dependencies": {
     "deep-equal": "^1.0.1",
     "eventemitter3": "^1.1.1",
-    "fbjs": "^0.7.2",
+    "fbjs": "^0.8.4",
     "hoist-non-react-statics": "^1.0.5",
     "querystring": "^0.2.0",
     "rimraf": "^2.5.1"

--- a/src/react/exposeMetrics.js
+++ b/src/react/exposeMetrics.js
@@ -1,4 +1,5 @@
 import React, {Component} from "react";
+import {canUseDOM} from "fbjs/lib/ExecutionEnvironment";
 import hoistStatics from "hoist-non-react-statics";
 import PropTypes from "./PropTypes";
 
@@ -27,6 +28,10 @@ function wrap(ComposedComponent) {
         };
 
         componentWillMount() {
+            if (!canUseDOM) {
+                return;
+            }
+
             mountedInstances.push(Metrics);
         }
 

--- a/src/react/metrics.js
+++ b/src/react/metrics.js
@@ -59,9 +59,13 @@ export default function metrics(metricsOrConfig, options = {}) {
             }
 
             componentWillMount() {
+                if (!canUseDOM) {
+                    return;
+                }
+
                 const instances = this.constructor.getMountedMetricsInstances();
                 // Ensure this component should only be added in one root location.
-                if (canUseDOM && instances.length === 1) {
+                if (instances.length === 1) {
                     invariant(
                         false,
                         "`metrics` should only be added once to the root level component. You have added to both %s and %s.",


### PR DESCRIPTION
`componentWillUnmount` does not fire on the server, so any logic set up in `componentWillMount` does not get cleaned up in Node. This patch prevents Node from accruing memory that is not garbage collected.