### PR TITLE
fix: Don't throw invariant error for missing pageView api when `enabl…

### DIFF
--- a/src/core/createMetrics.js
+++ b/src/core/createMetrics.js
@@ -445,6 +445,7 @@ export default function createMetrics(options) {
         setRouteState: metrics.setRouteState.bind(metrics),
         useTrackBinding: metrics.useTrackBinding.bind(metrics),
         destroy: metrics.destroy.bind(metrics),
+        get enabled() {return metrics.enabled;},
         get api() {return metrics.api;}
     };
 }

--- a/src/react/metrics.js
+++ b/src/react/metrics.js
@@ -77,7 +77,7 @@ export default function metrics(metricsOrConfig, options = {}) {
 
                 this._newRouteState = getNewRouteState(this.props);
                 if (this._newRouteState) {
-                    metricsInstance.setRouteState(this._newRouteState);
+                    this._getMetrics().setRouteState(this._newRouteState);
                 }
             }
             componentDidMount() {
@@ -88,7 +88,7 @@ export default function metrics(metricsOrConfig, options = {}) {
                         rootElement,
                         "`metrics` should be added to the root most component which renders node element for declarative tracking to work."
                     );
-                    metricsInstance.useTrackBinding(rootElement, attributePrefix);
+                    this._getMetrics().useTrackBinding(rootElement, attributePrefix);
                 }
 
                 if (this._newRouteState) {
@@ -99,7 +99,7 @@ export default function metrics(metricsOrConfig, options = {}) {
             componentWillReceiveProps(newProps) {
                 this._newRouteState = getNewRouteState(newProps, this.props);
                 if (this._newRouteState) {
-                    metricsInstance.setRouteState(this._newRouteState);
+                    this._getMetrics().setRouteState(this._newRouteState);
                 }
             }
             componentDidUpdate() {
@@ -113,7 +113,7 @@ export default function metrics(metricsOrConfig, options = {}) {
                 const index = instances.indexOf(ComposedComponent);
                 instances.splice(index, 1);
 
-                metricsInstance.destroy();
+                this._getMetrics().destroy();
             }
             _getMetrics() {
                 return metricsInstance;
@@ -127,6 +127,7 @@ export default function metrics(metricsOrConfig, options = {}) {
              */
             _handleRouteStateChange(routeState) {
                 const component = findNewRouteComponent();
+                const metrics = this._getMetrics();
                 let pageViewParams;
                 let shouldSuppress = false;
 
@@ -139,12 +140,12 @@ export default function metrics(metricsOrConfig, options = {}) {
                     }
                 }
 
-                if (autoTrackPageView && !shouldSuppress) {
+                if (metrics.enabled && autoTrackPageView && !shouldSuppress) {
                     invariant(
-                        typeof this._getMetrics().api.pageView === "function",
+                        typeof metrics.api.pageView === "function",
                         "react-metrics: 'pageView' api needs to be defined for automatic page view tracking."
                     );
-                    this._getMetrics().api.pageView(pageViewParams);
+                    metrics.api.pageView(pageViewParams);
                 }
             }
             /**

--- a/test/ReactMetrics/metrics.spec.js
+++ b/test/ReactMetrics/metrics.spec.js
@@ -138,6 +138,7 @@ describe("metrics", () => {
 
         const stub = sinon.stub(Application.prototype, "_getMetrics", () => {
             return {
+                ...metricsMock,
                 api: metricsContext
             };
         });
@@ -214,6 +215,33 @@ describe("metrics", () => {
                 </Route>
             </Router>
         ), node, execNextStep);
+    });
+    
+    it("should not throw invariant error when `enabled` is set to false in metrics config and pageView is not defined.", done => {
+        @metrics(metricsConfig)
+        class Application extends React.Component {
+            static displayName = "Application";
+
+            render() {
+                return (<div><h2>Appication</h2></div>);
+            }
+        }
+        
+        sinon.stub(Application.prototype, "_getMetrics", () => {
+            return {
+                ...metricsMock,
+                enabled: false,
+                api: {}
+            };
+        });
+
+        expect(() => {
+            ReactDOM.render((
+                <Router history={createHistory("/")}>
+                    <Route path="/" component={Application}/>
+                </Router>
+            ), node, done);
+        }).to.not.throw();
     });
 
     it("should not use track binding when 'useTrackBinding' is set to false.", done => {

--- a/test/ReactMetrics/willTrackPageView.spec.js
+++ b/test/ReactMetrics/willTrackPageView.spec.js
@@ -143,6 +143,7 @@ describe("willTrackPageView", () => {
 
         const pageView = sinon.stub(Application.prototype, "_getMetrics", () => {
             return {
+                ...metricsMock,
                 api: {
                     pageView(...args) {
                         expect(typeof args[0]).to.be.equal("object");

--- a/test/metricsMock.js
+++ b/test/metricsMock.js
@@ -1,4 +1,9 @@
 export default {
+    listen: () => {},
+    setRouteState: () => {},
+    useTrackBinding: () => {},
+    destroy: () => {},
+    get enabled() {return true;},
     api: {
         pageView() {},
         track() {}


### PR DESCRIPTION
addresses #28 
