### PR TITLE
Support ie10 quirks mode

### DIFF
--- a/src/core/useTrackBindingPlugin.js
+++ b/src/core/useTrackBindingPlugin.js
@@ -56,7 +56,7 @@ export class TrackBindingPlugin {
             return;
         }
 
-        let elem = event.target;
+        let elem = event.target || event.srcElement;
         let dataset = this._getData(elem);
 
         if (this._traverseParent) {


### PR DESCRIPTION
Small tweak to add support for tracking elements in ie10 quirks mode. Good fallback when event.target is not available.