### PR TITLE
Fix warning when using PropTypes via main package (fix #39)

### DIFF
--- a/package.json
+++ b/package.json
@@ -80,6 +80,7 @@
     "karma-webpack": "^1.7.0",
     "mocha": "^2.4.5",
     "path-to-regexp": "^1.2.1",
+    "prop-types": "^15.5.10",
     "react": "^15.0.1",
     "react-addons-test-utils": "^15.0.1",
     "react-dom": "^15.0.1",

--- a/src/react/MetricsElement.js
+++ b/src/react/MetricsElement.js
@@ -1,11 +1,11 @@
 import {
-    PropTypes,
     Component,
     Children,
     createElement,
     cloneElement,
     isValidElement
 } from "react";
+import PropTypes from "prop-types";
 import ReactDOM from "react-dom";
 import invariant from "fbjs/lib/invariant";
 import warning from "fbjs/lib/warning";

--- a/src/react/PropTypes.js
+++ b/src/react/PropTypes.js
@@ -1,6 +1,4 @@
-import {PropTypes} from "react";
-
-const {shape, object, string} = PropTypes;
+import {shape, object, string} from "prop-types";
 
 export const metrics = object;
 

--- a/src/react/metrics.js
+++ b/src/react/metrics.js
@@ -1,4 +1,5 @@
-import React, {PropTypes, Component} from "react";
+import React, {Component} from "react";
+import PropTypes from "prop-types";
 import ReactDOM from "react-dom";
 import invariant from "fbjs/lib/invariant";
 import {canUseDOM} from "fbjs/lib/ExecutionEnvironment";


### PR DESCRIPTION
When using react-metrics with React v15.5.0, React is throwing a Warning
message saying that using `PropTypes` from `React` package is now
deprecated, and the correct way of using it is through
[`prop-types`](https://www.npmjs.com/package/prop-types) package.

This commit introduces the use of this new `prop-types` package, and
changes the code to use this one instead of `React.PropTypes`.

Related:

* https://facebook.github.io/react/blog/2017/04/07/react-v15.5.0.html#new-deprecation-warnings
* https://facebook.github.io/react/blog/2017/04/07/react-v15.5.0.html#migrating-from-react.proptypes

---

Comments:

* I ran tests and they're all passing
* I tested it locally with our application, changing routes and tracking custom events, and everything seems to be ok

If you think I need to change anything, just let me know!