### PR TITLE
Fix for IE console log error. SVG elements in IE do not have a parentElement

### DIFF
--- a/src/core/useTrackBindingPlugin.js
+++ b/src/core/useTrackBindingPlugin.js
@@ -62,7 +62,7 @@ export class TrackBindingPlugin {
         if (this._traverseParent) {
             const rootElement = this._rootElement;
             while (elem !== rootElement) {
-                elem = elem.parentElement;
+                elem = elem.parentElement || elem.parentNode;
                 dataset = {...this._getData(elem), ...dataset};
             }
         }


### PR DESCRIPTION
This is a fix for #45 - SVG icons in IE do not have a parentElement so it seems like parentNode is also needed.

Thanks