### PR TITLE
Send target element along with track call

### DIFF
--- a/src/core/createMetrics.js
+++ b/src/core/createMetrics.js
@@ -371,11 +371,12 @@ export class Metrics extends EventEmitter {
      * @returns {Promise}
      * @private
      */
-    _addEventNameToPromise(eventName, promise, shouldMerge) {
+    _addEventNameToPromise(eventName, promise, shouldMerge, element) {
         return promise.then(
             function(state, data) {
                 data = [shouldMerge ? this._mergeWith(data, state) : data];
                 data.unshift(eventName);
+                element && data.push(element);
                 return data;
             }.bind(this, this.routeState)
         );
@@ -411,7 +412,7 @@ export class Metrics extends EventEmitter {
         }
 
         // set default page view event name when missing.
-        let [eventName, params] = args;
+        let [eventName, params, ,element] = args;
         if (!params && typeof eventName !== "string") {
             params = eventName;
             eventName = type === ActionTypes.PAGE_VIEW
@@ -434,7 +435,8 @@ export class Metrics extends EventEmitter {
             params = this._addEventNameToPromise(
                 eventName,
                 params,
-                shouldMerge
+                shouldMerge,
+                element
             );
         }
         args = [type, params];

--- a/src/core/useTrackBindingPlugin.js
+++ b/src/core/useTrackBindingPlugin.js
@@ -1,3 +1,4 @@
+/* eslint-disable prettier/prettier */
 import EventListener from "fbjs/lib/EventListener";
 import attr2obj from "./utils/attr2obj";
 
@@ -62,7 +63,8 @@ export class TrackBindingPlugin {
             return;
         }
 
-        let elem = event.target || event.srcElement;
+        var originalElem = event.target || event.srcElement;
+        var elem = originalElem;
         let dataset = this._getData(elem);
 
         if (this._traverseParent) {
@@ -83,7 +85,7 @@ export class TrackBindingPlugin {
 
         if (eventName) {
             delete dataset.eventName;
-            callback(eventName, dataset, mergePagedefaults === "true");
+            callback(eventName, dataset, mergePagedefaults === "true", originalElem);
         }
     }
 


### PR DESCRIPTION
We want to be able to default some track attributes based on the element type. If we have context of the clicked element we can begin auto tracking alot of data.