### PR TITLE
Fix Issue/59 syntax error calling custom vendor api without params

### DIFF
--- a/docs/Guides.md
+++ b/docs/Guides.md
@@ -33,6 +33,12 @@ A name of the vendor service to be returned as part of tracking response if defi
 An object, a class instance or a function which returns an object which exposes tracking APIs. You don't have to define `pageView` or `track` api, but keep in mind that `react-metrics` will assume those methods to exist for auto page view and declarative tracking and throws when not available.
 You can define `name` property in your api, which will be returned as part of tracking response.
 
+Custom `api` methods can take 3 arguments:
+
+```
+someMethod(eventType?: string, eventData?: Object, shouldMergeWithDefaultObject?: boolean)
+```
+
 Example:
 
 ```javascript

--- a/src/core/createMetrics.js
+++ b/src/core/createMetrics.js
@@ -164,7 +164,8 @@ export class Metrics extends EventEmitter {
      * @private
      */
     _callServices(type, promise) {
-        return promise.then((...params) => {
+        return promise.then((params) => {
+            params = params || [];
             const results = [];
             const services = this.services;
             const requestTimeout = this.requestTimeout;

--- a/src/core/createMetrics.js
+++ b/src/core/createMetrics.js
@@ -59,9 +59,8 @@ export class Metrics extends EventEmitter {
         super();
         this.enabled = options.enabled !== false;
         // undocumented option for unit test.
-        this.canUseDOM = options.canUseDOM !== undefined
-            ? !!options.canUseDOM
-            : canUseDOM;
+        this.canUseDOM =
+            options.canUseDOM !== undefined ? !!options.canUseDOM : canUseDOM;
         if (!this.canUseDOM) {
             this.enabled = false;
         }
@@ -70,9 +69,8 @@ export class Metrics extends EventEmitter {
         this.pageDefaults = options.pageDefaults || defaults.pageDefaults;
         this.pageViewEvent = options.pageViewEvent || defaults.pageViewEvent;
         this.requestTimeout = options.requestTimeout || defaults.requestTimeout;
-        this.cancelOnNext = options.cancelOnNext !== undefined
-            ? !!options.cancelOnNext
-            : true;
+        this.cancelOnNext =
+            options.cancelOnNext !== undefined ? !!options.cancelOnNext : true;
         this.vendors = Array.isArray(options.vendors)
             ? options.vendors
             : [options.vendors];
@@ -165,6 +163,7 @@ export class Metrics extends EventEmitter {
      */
     _callServices(type, promise) {
         return promise.then(params => {
+            params = params || [];
             const results = [];
             const services = this.services;
             const requestTimeout = this.requestTimeout;
@@ -199,13 +198,15 @@ export class Metrics extends EventEmitter {
                     if (apiExists) {
                         warning(
                             typeof apis[type] === "function",
-                            `'${type}'${name ? `(${name} Service)` : ""} is not a function`
+                            `'${type}'${
+                                name ? `(${name} Service)` : ""
+                            } is not a function`
                         );
                     }
-                    let requestPromise = apiExists &&
-                        typeof apis[type] === "function"
-                        ? apis[type](...params)
-                        : undefined;
+                    let requestPromise =
+                        apiExists && typeof apis[type] === "function"
+                            ? apis[type](...params)
+                            : undefined;
                     if (!isPromise(requestPromise)) {
                         requestPromise = Promise.resolve(requestPromise);
                     }
@@ -414,9 +415,8 @@ export class Metrics extends EventEmitter {
         let [eventName, params] = args;
         if (!params && typeof eventName !== "string") {
             params = eventName;
-            eventName = type === ActionTypes.PAGE_VIEW
-                ? this.pageViewEvent
-                : null;
+            eventName =
+                type === ActionTypes.PAGE_VIEW ? this.pageViewEvent : null;
         }
 
         // make sure `params` is a promise.

--- a/src/core/createMetrics.js
+++ b/src/core/createMetrics.js
@@ -164,7 +164,7 @@ export class Metrics extends EventEmitter {
      * @private
      */
     _callServices(type, promise) {
-        return promise.then(params => {
+        return promise.then((...params) => {
             const results = [];
             const services = this.services;
             const requestTimeout = this.requestTimeout;
@@ -204,7 +204,7 @@ export class Metrics extends EventEmitter {
                     }
                     let requestPromise = apiExists &&
                         typeof apis[type] === "function"
-                        ? params ? apis[type](...params) : apis[type]
+                        ? apis[type](...params)
                         : undefined;
                     if (!isPromise(requestPromise)) {
                         requestPromise = Promise.resolve(requestPromise);

--- a/src/core/createMetrics.js
+++ b/src/core/createMetrics.js
@@ -163,7 +163,6 @@ export class Metrics extends EventEmitter {
      */
     _callServices(type, promise) {
         return promise.then(params => {
-            params = params || [];
             const results = [];
             const services = this.services;
             const requestTimeout = this.requestTimeout;
@@ -205,7 +204,7 @@ export class Metrics extends EventEmitter {
                     }
                     let requestPromise =
                         apiExists && typeof apis[type] === "function"
-                            ? apis[type](...params)
+                            ? params ? apis[type](...params) : apis[type]()
                             : undefined;
                     if (!isPromise(requestPromise)) {
                         requestPromise = Promise.resolve(requestPromise);

--- a/src/core/createMetrics.js
+++ b/src/core/createMetrics.js
@@ -59,8 +59,9 @@ export class Metrics extends EventEmitter {
         super();
         this.enabled = options.enabled !== false;
         // undocumented option for unit test.
-        this.canUseDOM =
-            options.canUseDOM !== undefined ? !!options.canUseDOM : canUseDOM;
+        this.canUseDOM = options.canUseDOM !== undefined
+            ? !!options.canUseDOM
+            : canUseDOM;
         if (!this.canUseDOM) {
             this.enabled = false;
         }
@@ -69,8 +70,9 @@ export class Metrics extends EventEmitter {
         this.pageDefaults = options.pageDefaults || defaults.pageDefaults;
         this.pageViewEvent = options.pageViewEvent || defaults.pageViewEvent;
         this.requestTimeout = options.requestTimeout || defaults.requestTimeout;
-        this.cancelOnNext =
-            options.cancelOnNext !== undefined ? !!options.cancelOnNext : true;
+        this.cancelOnNext = options.cancelOnNext !== undefined
+            ? !!options.cancelOnNext
+            : true;
         this.vendors = Array.isArray(options.vendors)
             ? options.vendors
             : [options.vendors];
@@ -197,15 +199,13 @@ export class Metrics extends EventEmitter {
                     if (apiExists) {
                         warning(
                             typeof apis[type] === "function",
-                            `'${type}'${
-                                name ? `(${name} Service)` : ""
-                            } is not a function`
+                            `'${type}'${name ? `(${name} Service)` : ""} is not a function`
                         );
                     }
-                    let requestPromise =
-                        apiExists && typeof apis[type] === "function"
-                            ? params ? apis[type](...params) : apis[type]()
-                            : undefined;
+                    let requestPromise = apiExists &&
+                        typeof apis[type] === "function"
+                        ? params ? apis[type](...params) : apis[type]
+                        : undefined;
                     if (!isPromise(requestPromise)) {
                         requestPromise = Promise.resolve(requestPromise);
                     }
@@ -414,8 +414,9 @@ export class Metrics extends EventEmitter {
         let [eventName, params] = args;
         if (!params && typeof eventName !== "string") {
             params = eventName;
-            eventName =
-                type === ActionTypes.PAGE_VIEW ? this.pageViewEvent : null;
+            eventName = type === ActionTypes.PAGE_VIEW
+                ? this.pageViewEvent
+                : null;
         }
 
         // make sure `params` is a promise.

--- a/src/core/createMetrics.js
+++ b/src/core/createMetrics.js
@@ -164,7 +164,7 @@ export class Metrics extends EventEmitter {
      * @private
      */
     _callServices(type, promise) {
-        return promise.then((params) => {
+        return promise.then(params => {
             params = params || [];
             const results = [];
             const services = this.services;

--- a/test/core/createMetrics.spec.js
+++ b/test/core/createMetrics.spec.js
@@ -237,6 +237,16 @@ describe("Metrics", () => {
         metricsInstance.api.someMethod();
     });
 
+    it("allows a custom vendor api methods with 2 arguments", done => {
+        const metricsInstance = new Metrics(metricsConfig);
+        const stub = sinon.stub(console, "log", (logName, event) => {
+            expect(logName).to.equal("someMethod 1 2 undefined");
+            done();
+            stub.restore();
+        });
+        metricsInstance.api.someMethod(1, 2, 3);
+    });
+
     it("should have console log when debug flag is set", done => {
         const missingPageDefaultsConfig = Object.assign({}, metricsConfig, {
             debug: true

--- a/test/core/createMetrics.spec.js
+++ b/test/core/createMetrics.spec.js
@@ -173,48 +173,22 @@ describe("Metrics", () => {
     it("allows a client to listen event", done => {
         const metricsInstance = new Metrics(metricsConfig);
         metricsInstance.listen(event => {
-            expect(event)
-                .to.have.property("type")
-                .and.equal("identify");
-            expect(event)
-                .to.have.property("status")
-                .and.equal("success");
+            expect(event).to.have.property("type").and.equal("identify");
+            expect(event).to.have.property("status").and.equal("success");
         });
         metricsInstance.listen(event => {
-            expect(event)
-                .to.have.property("type")
-                .and.equal("identify");
-            expect(event)
-                .to.have.property("status")
-                .and.equal("success");
+            expect(event).to.have.property("type").and.equal("identify");
+            expect(event).to.have.property("status").and.equal("success");
             done();
         });
         metricsInstance.api.identify({user: "testUser"});
     });
 
-    it("allows a custom vendor method without arguments", done => {
-        const metricsInstance = new Metrics(metricsConfig);
-        metricsInstance.listen(event => {
-            expect(event)
-                .to.have.property("type")
-                .and.equal("someMethod");
-            expect(event)
-                .to.have.property("status")
-                .and.equal("success");
-            done();
-        });
-        metricsInstance.api.someMethod();
-    });
-
     it("allows a client to listen event by api", done => {
         const metricsInstance = new Metrics(metricsConfig);
         metricsInstance.listen("pageView", event => {
-            expect(event)
-                .to.have.property("type")
-                .and.equal("pageView");
-            expect(event)
-                .to.have.property("status")
-                .and.equal("success");
+            expect(event).to.have.property("type").and.equal("pageView");
+            expect(event).to.have.property("status").and.equal("success");
             done();
         });
         metricsInstance.api.pageView();
@@ -249,6 +223,20 @@ describe("Metrics", () => {
         }, 0);
     });
 
+    it("allows a custom vendor method without arguments", done => {
+        const metricsInstance = new Metrics(metricsConfig);
+        metricsInstance.listen(event => {
+            expect(event)
+                .to.have.property("type")
+                .and.equal("someMethod");
+            expect(event)
+                .to.have.property("status")
+                .and.equal("success");
+            done();
+        });
+        metricsInstance.api.someMethod();
+    });
+
     it("should have console log when debug flag is set", done => {
         const missingPageDefaultsConfig = Object.assign({}, metricsConfig, {
             debug: true
@@ -256,12 +244,8 @@ describe("Metrics", () => {
         const metricsInstance = new Metrics(missingPageDefaultsConfig);
         const stub = sinon.stub(console, "log", (logName, event) => {
             expect(logName).to.equal("track result");
-            expect(event)
-                .to.have.property("type")
-                .and.equal("pageView");
-            expect(event)
-                .to.have.property("status")
-                .and.equal("success");
+            expect(event).to.have.property("type").and.equal("pageView");
+            expect(event).to.have.property("status").and.equal("success");
             done();
             stub.restore();
         });

--- a/test/core/createMetrics.spec.js
+++ b/test/core/createMetrics.spec.js
@@ -237,14 +237,14 @@ describe("Metrics", () => {
         metricsInstance.api.someMethod();
     });
 
-    it("allows a custom vendor api methods with 2 arguments", done => {
+    it("passes first 2 arguments through custom vendor api methods", done => {
         const metricsInstance = new Metrics(metricsConfig);
         const stub = sinon.stub(console, "log", (logName, event) => {
-            expect(logName).to.equal("someMethod 1 2 undefined");
+            expect(logName).to.equal("argumentTest 1 2 undefined");
             done();
             stub.restore();
         });
-        metricsInstance.api.someMethod(1, 2, 3);
+        metricsInstance.api.argumentTest(1, 2, 3);
     });
 
     it("should have console log when debug flag is set", done => {

--- a/test/core/createMetrics.spec.js
+++ b/test/core/createMetrics.spec.js
@@ -173,22 +173,48 @@ describe("Metrics", () => {
     it("allows a client to listen event", done => {
         const metricsInstance = new Metrics(metricsConfig);
         metricsInstance.listen(event => {
-            expect(event).to.have.property("type").and.equal("identify");
-            expect(event).to.have.property("status").and.equal("success");
+            expect(event)
+                .to.have.property("type")
+                .and.equal("identify");
+            expect(event)
+                .to.have.property("status")
+                .and.equal("success");
         });
         metricsInstance.listen(event => {
-            expect(event).to.have.property("type").and.equal("identify");
-            expect(event).to.have.property("status").and.equal("success");
+            expect(event)
+                .to.have.property("type")
+                .and.equal("identify");
+            expect(event)
+                .to.have.property("status")
+                .and.equal("success");
             done();
         });
         metricsInstance.api.identify({user: "testUser"});
     });
 
+    it("allows a custom vendor method without arguments", done => {
+        const metricsInstance = new Metrics(metricsConfig);
+        metricsInstance.listen(event => {
+            expect(event)
+                .to.have.property("type")
+                .and.equal("someMethod");
+            expect(event)
+                .to.have.property("status")
+                .and.equal("success");
+            done();
+        });
+        metricsInstance.api.someMethod();
+    });
+
     it("allows a client to listen event by api", done => {
         const metricsInstance = new Metrics(metricsConfig);
         metricsInstance.listen("pageView", event => {
-            expect(event).to.have.property("type").and.equal("pageView");
-            expect(event).to.have.property("status").and.equal("success");
+            expect(event)
+                .to.have.property("type")
+                .and.equal("pageView");
+            expect(event)
+                .to.have.property("status")
+                .and.equal("success");
             done();
         });
         metricsInstance.api.pageView();
@@ -230,8 +256,12 @@ describe("Metrics", () => {
         const metricsInstance = new Metrics(missingPageDefaultsConfig);
         const stub = sinon.stub(console, "log", (logName, event) => {
             expect(logName).to.equal("track result");
-            expect(event).to.have.property("type").and.equal("pageView");
-            expect(event).to.have.property("status").and.equal("success");
+            expect(event)
+                .to.have.property("type")
+                .and.equal("pageView");
+            expect(event)
+                .to.have.property("status")
+                .and.equal("success");
             done();
             stub.restore();
         });

--- a/test/metrics.config.js
+++ b/test/metrics.config.js
@@ -32,7 +32,8 @@ export default {
                         });
                     });
                 },
-                someMethod() {
+                someMethod(a, b, c) {
+                    console.log(`someMethod ${a} ${b} ${c}`);
                     return new Promise(resolve => {
                         resolve();
                     });

--- a/test/metrics.config.js
+++ b/test/metrics.config.js
@@ -32,8 +32,13 @@ export default {
                         });
                     });
                 },
-                someMethod(a, b, c) {
-                    console.log(`someMethod ${a} ${b} ${c}`);
+                someMethod() {
+                    return new Promise(resolve => {
+                        resolve();
+                    });
+                },
+                argumentTest(a, b, c) {
+                    console.log(`argumentTest ${a} ${b} ${c}`, b);
                     return new Promise(resolve => {
                         resolve();
                     });

--- a/test/metrics.config.js
+++ b/test/metrics.config.js
@@ -31,6 +31,11 @@ export default {
                             user
                         });
                     });
+                },
+                someMethod() {
+                    return new Promise(resolve => {
+                        resolve();
+                    });
                 }
             }
         }


### PR DESCRIPTION
Fixes Issue #59 

* (refactor) fix syntax error when custom vendor api method called without params
* (refactor) prettify