### PR TITLE
Update out of date dependencies to latest versions

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,9 +33,9 @@
   ],
   "dependencies": {
     "deep-equal": "^1.0.1",
-    "eventemitter3": "^1.1.1",
-    "fbjs": "^0.8.4",
-    "hoist-non-react-statics": "^1.0.5",
+    "eventemitter3": "3.1.2",
+    "fbjs": "1.0.0",
+    "hoist-non-react-statics": "3.3.0",
     "querystring": "^0.2.0",
     "rimraf": "^2.5.1"
   },


### PR DESCRIPTION
# Features

I updated dependencies to be up to date.

**eventemitter3**, **fbjs** & **hoist-non-react-statics**, were out of date
